### PR TITLE
docs: Add example for auto-activating extended mixins

### DIFF
--- a/src/main/resources/META-INF/definitions.cnd
+++ b/src/main/resources/META-INF/definitions.cnd
@@ -7,3 +7,7 @@
 [cent:overridesContent] > jnt:content, jmix:editorialContent, mix:title, jmix:structuredContent
  - text (string, richtext) mandatory i18n
  - image (weakreference, picker[type=image]) indexed=no
+
+[cemix:myMixinToggle] mixin
+extends = cent:overridesContent
+- mixinToggleField (string)

--- a/src/main/resources/META-INF/jahia-content-editor-forms/forms/cent_overridesContent.json
+++ b/src/main/resources/META-INF/jahia-content-editor-forms/forms/cent_overridesContent.json
@@ -31,8 +31,19 @@
             {
               "name": "ce:systemName",
               "hide": true
+            },
+            {
+              "rank": 6.0,
+              "name": "mixinToggleField",
+              "declaringNodeType": "cemix:myMixinToggle"
             }
           ]
+        },
+        {
+          "name": "cemix:myMixinToggle",
+          "isAlwaysActivated": true,
+          "alwaysPresent": true,
+          "hide": true
         }
       ]
     },


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## Description

Similar override that we use here https://github.com/Jahia/site-settings-seo/blob/master/src/main/resources/META-INF/jahia-content-editor-forms/forms/jnt_page_rename_description.json#L34

Associated entry in the academy (to be published): https://edit.jahia.com/cms/render/default/documentation/jahia-cms/jahia-8.2/developer/extending-and-customizing-jahia-ui/customizing-content-editor-forms/examples-of-content-definition-json-overrides#enable-extended-mixin-by-default-and-hiding-field-set-toggle